### PR TITLE
Feature/ask to exit

### DIFF
--- a/Runtime/FsmDataUnit.cs
+++ b/Runtime/FsmDataUnit.cs
@@ -10,7 +10,7 @@ namespace SensenToolkit.StateMachine
     where TMachine : FsmMachine
     where TDataComponent : MonoBehaviour
     {
-        private TMachine _machine;
+        protected TMachine _machine;
         protected override void Definition()
         {
             Type dataType = typeof(TDataComponent);

--- a/Runtime/FsmDataUnit.cs
+++ b/Runtime/FsmDataUnit.cs
@@ -13,26 +13,14 @@ namespace SensenToolkit.StateMachine
         private TMachine _machine;
         protected override void Definition()
         {
-            Type dataType = typeof(TMachine);
-            foreach (var (property, attr) in GetExposedProperties())
+            Type dataType = typeof(TDataComponent);
+            foreach (var (property, attr) in FsmExposeAttribute.GetExposedProperties<TDataComponent>())
             {
-                ValueOutput(property.PropertyType, attr.Name, (flow) => {
+                ValueOutput(property.PropertyType, attr.Name ?? property.Name, (flow) => {
                     FsmMachineFetcher.GetFromFlow(flow, ref _machine);
                     MonoBehaviour dataComponent = _machine.GetDataComponent<TDataComponent>();
                     return property.GetValue(dataComponent);
                 });
-            }
-        }
-
-        public IEnumerable<(PropertyInfo, FsmExposeAttribute)> GetExposedProperties()
-        {
-            foreach (var property in typeof(TMachine).GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy))
-            {
-                FsmExposeAttribute attr = property.GetCustomAttribute<FsmExposeAttribute>();
-                if (attr != null)
-                {
-                    yield return (property, attr);
-                }
             }
         }
     }

--- a/Runtime/FsmDefaultMachineDataUnit.cs
+++ b/Runtime/FsmDefaultMachineDataUnit.cs
@@ -1,0 +1,11 @@
+using Unity.VisualScripting;
+
+namespace SensenToolkit.StateMachine
+{
+    [UnitCategory("SensenFSM")]
+    public class FsmDefaultMachineDataUnit : FsmMachineDataUnit<FsmMachine>
+    {
+        [FsmExpose]
+        public bool CurrentStateHasAskedToExit => _machine.CurrentStateHasAskedToExit;
+    }
+}

--- a/Runtime/FsmDefaultMachineDataUnit.cs.meta
+++ b/Runtime/FsmDefaultMachineDataUnit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1277f93872fe44146beb2ab2a3d67104
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FsmExposeAttribute.cs
+++ b/Runtime/FsmExposeAttribute.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
 
 namespace SensenToolkit.StateMachine
 {
@@ -7,9 +10,22 @@ namespace SensenToolkit.StateMachine
     {
         public string Name;
 
-        public FsmExposeAttribute(string name)
+        public FsmExposeAttribute(string name = null)
         {
             this.Name = name;
+        }
+
+        public static IEnumerable<(PropertyInfo, FsmExposeAttribute)> GetExposedProperties<TComponent>()
+        where TComponent : Component
+        {
+            foreach (var property in typeof(TComponent).GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy))
+            {
+                FsmExposeAttribute attr = property.GetCustomAttribute<FsmExposeAttribute>();
+                if (attr != null)
+                {
+                    yield return (property, attr);
+                }
+            }
         }
     }
 }

--- a/Runtime/FsmMachine.cs
+++ b/Runtime/FsmMachine.cs
@@ -11,6 +11,7 @@ namespace SensenToolkit.StateMachine
     public abstract class FsmMachine : MonoBehaviour
     {
         public FsmState CurrentState { get; private set; }
+        public bool CurrentStateHasAskedToExit => CurrentState?.HasAskedToExit == true;
         private Dictionary<Type, FsmState> _states;
         private Dictionary<Type, FsmState> States
             => _states ??= GetStates();

--- a/Runtime/FsmMachine.cs
+++ b/Runtime/FsmMachine.cs
@@ -38,7 +38,7 @@ namespace SensenToolkit.StateMachine
             States[typeof(TState)].Exit();
         }
 
-        private FsmState GetState<TState>()
+        internal FsmState GetState<TState>()
         where TState : FsmState
         {
             if (States.TryGetValue(typeof(TState), out FsmState state))

--- a/Runtime/FsmState.cs
+++ b/Runtime/FsmState.cs
@@ -9,6 +9,7 @@ namespace SensenToolkit.StateMachine
         public bool IsEntering { get; private set; }
         public bool IsExiting { get; private set; }
         public bool IsCurrent { get; private set; }
+        [FsmExpose] public bool HasAskedToExit { get; private set; }
 
         public void Boot()
         {
@@ -24,12 +25,18 @@ namespace SensenToolkit.StateMachine
         }
         public void Exit()
         {
+            HasAskedToExit = false;
             this.IsExiting = true;
             OnExit();
             this.enabled = false;
             this.IsExiting = false;
             this.IsCurrent = false;
         }
+        protected void AskToExit()
+        {
+            HasAskedToExit = true;
+        }
+
         protected virtual void OnEnter()
         {}
 


### PR DESCRIPTION
* Creates protected method `FsmState.AskToExit()`, which is useful to easily transition to the next state after finishing an operation.
* Creates FsmDefaultMachineDataUnit and uses it to expose if the state asked to exit so it can be used on transitions.
* [FsmExpose] uses the property name as a default name.
* FsmExpose can be used in FsmState. It'll be exposed in its FsmStateUnit.