### PR TITLE
Adds FsmSuperState and adds support to it on FsmMachine

### DIFF
--- a/Runtime/FsmState.cs
+++ b/Runtime/FsmState.cs
@@ -15,19 +15,21 @@ namespace SensenToolkit.StateMachine
         {
             this.enabled = false;
         }
-        public void Enter()
+        public void EnterFrom(FsmState previousState)
         {
             this.IsCurrent = true;
             this.IsEntering = true;
             this.enabled = true;
             OnEnter();
+            OnEnterFrom(previousState);
             this.IsEntering = false;
         }
-        public void Exit()
+        public void ExitTo(FsmState nextState)
         {
             HasAskedToExit = false;
             this.IsExiting = true;
             OnExit();
+            OnExitTo(nextState);
             this.enabled = false;
             this.IsExiting = false;
             this.IsCurrent = false;
@@ -41,6 +43,11 @@ namespace SensenToolkit.StateMachine
         {}
 
         protected virtual void OnExit()
+        {}
+        protected virtual void OnEnterFrom(FsmState previousState)
+        {}
+
+        protected virtual void OnExitTo(FsmState nextState)
         {}
 
     }

--- a/Runtime/FsmStateUnit.cs
+++ b/Runtime/FsmStateUnit.cs
@@ -1,31 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Unity.VisualScripting;
+using UnityEngine;
 
 namespace SensenToolkit.StateMachine
 {
+    public readonly struct VisualScriptingStateData
+    {
+        public int Depth { get; }
+        public string Title { get; }
+        public string ParentTitle { get; }
+        public string RootTitle { get; }
+        public Guid ParentGuid { get; }
+        public IEnumerable<Guid> AncestorGuids { get; }
+
+        public VisualScriptingStateData(int depth, string title, string parentTitle, string rootTitle, Guid parentGuid, IEnumerable<Guid> ancestorGuids)
+        {
+            Depth = depth;
+            Title = title;
+            ParentTitle = parentTitle;
+            RootTitle = rootTitle;
+            ParentGuid = parentGuid;
+            AncestorGuids = ancestorGuids;
+        }
+    }
     public abstract class FsmStateUnit<TMachine, TState> : Unit
     where TMachine : FsmMachine
     where TState : FsmState
     {
         private ControlInput _enter;
-        private ControlInput _exit;
         private TMachine _machine;
 
         protected override void Definition()
         {
             _enter = ControlInput(nameof(_enter), Enter);
-            _exit = ControlInput(nameof(_exit), Exit);
         }
 
         private ControlOutput Enter(Flow flow)
         {
             FsmMachineFetcher.GetFromFlow(flow, ref _machine);
-            _machine.OnEnterState<TState>();
-            return null;
-        }
-
-        private ControlOutput Exit(Flow flow)
-        {
-            _machine.OnExitState<TState>();
+            IGraph parentGraph = flow.stack.parentElement.graph;
+            IGraph rootGraph = flow.stack.rootGraph;
+            System.Guid parentGuid = parentGraph == rootGraph ? System.Guid.Empty : flow.stack.parentElementGuids.SkipLast(1).Last();
+            VisualScriptingStateData data = new(
+                depth: flow.stack.depth - 2,
+                title: flow.stack.graph.title,
+                parentTitle: parentGraph.title,
+                rootTitle: rootGraph.title,
+                parentGuid: parentGuid,
+                ancestorGuids: flow.stack.parentElementGuids.SkipLast(1)
+            );
+            _machine.TransitToState<TState>(data);
             return null;
         }
     }

--- a/Runtime/FsmSuperState.cs
+++ b/Runtime/FsmSuperState.cs
@@ -1,0 +1,6 @@
+namespace SensenToolkit.StateMachine
+{
+    public abstract class FsmSuperState : FsmState
+    {
+    }
+}

--- a/Runtime/FsmSuperState.cs.meta
+++ b/Runtime/FsmSuperState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e36165068f42624419f34eeff526dc74
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Creates FsmSuperState with hooks for Entering and Exiting from a SuperState.
  * To use it is necessary to create a FsmStateUnit that will be the entry point of the SuperState in the visual scripting graph. This entry point unit needs to have a transition without condition so it will transit to the next state on the first update.
  * OnExit will be called on any transition that takes the flow to outside the super state.
  * When entering or exiting a superstate, the order of the calls will be:
    ```
    // Entering
    1. SuperState.OnEnter
    2. InnerEntryState.OnEnter
    
    // Exiting
    3. InnerExitState.OnExit
    4. SuperState.OnExit
    ```
* Adds the callback methods `FsmState.OnEnterFrom(FsmState previousState)` and  `FsmState.OnExitTo(FsmState nextState)`. Those callbacks have extra information that can be used by the state to take decisions.
